### PR TITLE
feat: Add create role button command

### DIFF
--- a/commands/create_role_button.go
+++ b/commands/create_role_button.go
@@ -96,7 +96,7 @@ func CreateRoleButtonHandler(e *handler.CommandEvent) error {
 
 	// Check if the specific role in question is one the user can assign
 	if !permissions.Has(role.Permissions) {
-		_ = respondWithContentEph(e, "You don't have permissions to assign that role.")
+		_ = respondWithContentEph(e, "You cannot assign a role with permissions you do not have.")
 		return nil
 	}
 

--- a/commands/create_role_button.go
+++ b/commands/create_role_button.go
@@ -90,7 +90,7 @@ func CreateRoleButtonHandler(e *handler.CommandEvent) error {
 
 	// Check if the user has permission to assign roles
 	if !permissions.Has(discord.PermissionManageRoles) {
-		_ = respondWithContentEph(e, "You don't have permissions to assign roles.")
+		_ = respondWithContentEph(e, "You need the Manage Roles permission to create a role button.")
 		return nil
 	}
 

--- a/commands/create_role_button.go
+++ b/commands/create_role_button.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/handler"
+	"github.com/disgoorg/json"
+	"github.com/myrkvi/heimdallr/utils"
+)
+
+var CreateRoleButtonCommand = discord.SlashCommandCreate{
+	Name: "create-role-button",
+	NameLocalizations: map[discord.Locale]string{
+		discord.LocaleNorwegian: "lag-rolleknapp",
+	},
+	Description: "Create a button that assigns a role to the user when clicked.",
+	DescriptionLocalizations: map[discord.Locale]string{
+		discord.LocaleNorwegian: "Lag ein knapp som gjev brukaren ei rolle når han vert trykt på.",
+	},
+
+	DMPermission:             utils.Ref(false),
+	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionManageRoles),
+
+	Options: []discord.ApplicationCommandOption{
+		discord.ApplicationCommandOptionRole{
+			Name: "role",
+			NameLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "rolle",
+			},
+			Description: "The role to assign to the user.",
+			DescriptionLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "Rollen som skal gjevast til brukaren.",
+			},
+			Required: true,
+		},
+		discord.ApplicationCommandOptionString{
+			Name: "instructions",
+			NameLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "instruksjonar",
+			},
+			Description: "Instructions to display to the user above the button.",
+			DescriptionLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "Instruksjonar som skal visast til brukaren over knappen.",
+			},
+			Required: false,
+		},
+		discord.ApplicationCommandOptionString{
+			Name: "text",
+			NameLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "tekst",
+			},
+			Description: "The text to display on the button.",
+			DescriptionLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "Teksten som skal visast på knappen.",
+			},
+			Required: false,
+		},
+	},
+}
+
+func CreateRoleButtonHandler(e *handler.CommandEvent) error {
+	if e.GuildID() == nil {
+		slog.Warn("Received create role button command in DMs or guild ID is otherwise nil")
+		return ErrEventNoGuildID
+	}
+
+	slog.Info(
+		"Received create role button command",
+		"guildID",
+		e.GuildID(),
+		"user",
+		e.User().ID,
+	)
+
+	permissions := e.Member().Permissions
+
+	role := e.SlashCommandInteractionData().Role("role")
+
+	instructions := e.SlashCommandInteractionData().String("instructions")
+	if instructions == "" {
+		instructions = fmt.Sprintf("Click the button below to get the **%s** role.", role.Name)
+	}
+
+	text := e.SlashCommandInteractionData().String("text")
+	if text == "" {
+		text = "Get role"
+	}
+
+	// Check if the user has permission to assign roles
+	if !permissions.Has(discord.PermissionManageRoles) {
+		_ = respondWithContentEph(e, "You don't have permissions to assign roles.")
+		return nil
+	}
+
+	// Check if the specific role in question is one the user can assign
+	if !permissions.Has(role.Permissions) {
+		_ = respondWithContentEph(e, "You don't have permissions to assign that role.")
+		return nil
+	}
+
+	// Create the button
+
+	return e.CreateMessage(discord.NewMessageCreateBuilder().
+		SetContent(instructions).
+		AddActionRow(discord.NewPrimaryButton(text, fmt.Sprintf("/role/assign/%s", role.ID.String()))).
+		SetAllowedMentions(&discord.AllowedMentions{}).
+		Build())
+}

--- a/components/role_assign_button.go
+++ b/components/role_assign_button.go
@@ -1,0 +1,45 @@
+package components
+
+import (
+	_ "embed"
+	"log/slog"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/handler"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+func RoleAssignButtonHandler(e *handler.ComponentEvent) error {
+	if e.GuildID() == nil {
+		slog.Warn("Received role assign button interaction in DMs or guild ID is otherwise nil")
+		return nil
+	}
+
+	slog.Info(
+		"Received role assign button interaction",
+		"guildID",
+		e.GuildID(),
+		"user",
+		e.User().ID,
+		"roleID",
+		e.Variables["roleID"],
+	)
+
+	roleID, err := snowflake.Parse(e.Variables["roleID"])
+	if err != nil {
+		slog.Warn("Failed to parse roleID", "roleID", e.Variables["roleID"], "err", err)
+		return nil
+	}
+
+	err = e.Client().Rest().AddMemberRole(*e.GuildID(), e.User().ID, roleID)
+
+	if err != nil {
+		return err
+	}
+
+	return e.CreateMessage(discord.NewMessageCreateBuilder().
+		SetContent("Role assigned!").
+		SetEphemeral(true).
+		SetAllowedMentions(&discord.AllowedMentions{}).
+		Build())
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/disgoorg/disgo/handler"
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/myrkvi/heimdallr/commands"
+	"github.com/myrkvi/heimdallr/components"
 	_ "github.com/myrkvi/heimdallr/config"
 	"github.com/myrkvi/heimdallr/listeners"
 	"github.com/myrkvi/heimdallr/model"
@@ -84,6 +85,10 @@ func main() {
 	r.Command("/kick/with-message", commands.KickWithMessageHandler)
 	r.Command("/ban/with-message", commands.BanWithMessageHandler)
 	r.Command("/ban/until", commands.BanUntilHandler)
+
+	r.Command("/create-role-button", commands.CreateRoleButtonHandler)
+	r.Component("/role/assign/{roleID}", components.RoleAssignButtonHandler)
+
 	commandCreates := []discord.ApplicationCommandCreate{
 		commands.PingCommand,
 		commands.QuoteCommand,
@@ -95,6 +100,7 @@ func main() {
 		commands.BanCommand,
 		commands.ApproveSlashCommand,
 		commands.ApproveUserCommand,
+		commands.CreateRoleButtonCommand,
 	}
 
 	client, err := disgo.New(token,


### PR DESCRIPTION
Allows for users to add a specific role using a button, given that they have access to the channel where the button message exists.