### PR TITLE
Fix ban duration not in log reason and remove testing duration (1min)

### DIFF
--- a/commands/ban.go
+++ b/commands/ban.go
@@ -68,10 +68,6 @@ var BanCommand = discord.SlashCommandCreate{
 
 var durationChoices = []discord.ApplicationCommandOptionChoiceString{
 	{
-		Name:  "1 minute",
-		Value: "1m",
-	},
-	{
 		Name:  "1 week",
 		Value: "1w",
 	},

--- a/commands/ban.go
+++ b/commands/ban.go
@@ -167,7 +167,11 @@ func banHandlerInner(e *handler.CommandEvent, user discord.User, sendReason bool
 	}
 
 	err := e.Client().Rest().AddBan(guild.ID, user.ID, 0,
-		rest.WithReason(fmt.Sprintf("Banned by: %s (%s), with message: %s", e.User().Username, e.User().ID, reason)))
+		rest.WithReason(fmt.Sprintf("Banned by: %s (%s) %s, with message: %s",
+			e.User().Username, e.User().ID,
+			utils.Iif(duration != "", fmt.Sprintf("for %s", duration), ""),
+			reason,
+		)))
 	if err != nil {
 		return e.CreateMessage(
 			discord.NewMessageCreateBuilder().


### PR DESCRIPTION
Fixes the Audit Log reason given for a ban, so that it includes the duration of the ban, if there is one. This will then be displayed in the Audit Log, and in the message posted by Heimdallr in the moderator channel when a ban event occurs.

Additionally, the testing duration of one minute has been removed from the available durations in the `/ban until` command. Heimdallr only checks which bans should be lifted every fifteen minutes, so this duration is misleading at best.