### PR TITLE
Fix: Add audit log reason when assigning role from button.

### DIFF
--- a/components/role_assign_button.go
+++ b/components/role_assign_button.go
@@ -1,13 +1,12 @@
 package components
 
 import (
-	_ "embed"
 	"fmt"
-	"github.com/disgoorg/disgo/rest"
 	"log/slog"
 
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/handler"
+	"github.com/disgoorg/disgo/rest"
 	"github.com/disgoorg/snowflake/v2"
 )
 

--- a/components/role_assign_button.go
+++ b/components/role_assign_button.go
@@ -2,6 +2,8 @@ package components
 
 import (
 	_ "embed"
+	"fmt"
+	"github.com/disgoorg/disgo/rest"
 	"log/slog"
 
 	"github.com/disgoorg/disgo/discord"
@@ -31,7 +33,19 @@ func RoleAssignButtonHandler(e *handler.ComponentEvent) error {
 		return nil
 	}
 
-	err = e.Client().Rest().AddMemberRole(*e.GuildID(), e.User().ID, roleID)
+	customID := e.ButtonInteractionData().CustomID()
+	comp := e.Message.ComponentByID(customID)
+	componentLabel := "role button"
+	if comp != nil {
+		switch x := comp.(type) {
+		case discord.ButtonComponent:
+			componentLabel = fmt.Sprintf("role button \"%s\"", x.Label)
+		}
+	}
+
+	err = e.Client().Rest().AddMemberRole(*e.GuildID(), e.User().ID, roleID,
+		rest.WithReason(fmt.Sprintf("User pressed %s", componentLabel)),
+	)
 
 	if err != nil {
 		return err

--- a/components/role_assign_button.go
+++ b/components/role_assign_button.go
@@ -44,7 +44,7 @@ func RoleAssignButtonHandler(e *handler.ComponentEvent) error {
 	}
 
 	err = e.Client().Rest().AddMemberRole(*e.GuildID(), e.User().ID, roleID,
-		rest.WithReason(fmt.Sprintf("User pressed %s", componentLabel)),
+		rest.WithReason(fmt.Sprintf("User pressed %s in channel \"%s\"", componentLabel, e.Channel().Name())),
 	)
 
 	if err != nil {

--- a/components/role_assign_button.go
+++ b/components/role_assign_button.go
@@ -48,6 +48,10 @@ func RoleAssignButtonHandler(e *handler.ComponentEvent) error {
 	)
 
 	if err != nil {
+		_ = e.CreateMessage(discord.NewMessageCreateBuilder().
+			SetContent("Failed to assign role. This is likely due to the bot not having the required permissions.").
+			SetEphemeral(true).
+			Build())
 		return err
 	}
 


### PR DESCRIPTION
Adds an audit log reason to the role given when users press a button that assigns roles (created with `/create-role-button`). It now also replied with an ephemeral message if it is unable to assign the role.