### PR TITLE
Migrate from LiteFS Cloud to Litestream

### DIFF
--- a/_fly/Dockerfile
+++ b/_fly/Dockerfile
@@ -2,14 +2,16 @@ FROM golang:alpine AS build
 
 COPY . .
 
-RUN ls -lah
 RUN go mod download
 RUN go build -ldflags "-s -w" -o /bin/heimdallr
 
 FROM alpine:latest
+ARG ENV=invalid
 COPY _fly/litefs.yml ./
+COPY _fly/litestream.${ENV}.yml /etc/litestream.yml
 COPY --from=build /bin/heimdallr /bin/heimdallr
-COPY --from=flyio/litefs:0.5 /usr/local/bin/litefs /bin/litefs
+#COPY --from=flyio/litefs:0.5 /usr/local/bin/litefs /bin/litefs
+COPY --from=litestream/litestream:0.3 /usr/local/bin/litestream /bin/litestream
 RUN apk add ca-certificates fuse3 sqlite
 
-ENTRYPOINT litefs mount
+ENTRYPOINT litestream replicate

--- a/_fly/litestream.production.yml
+++ b/_fly/litestream.production.yml
@@ -1,0 +1,9 @@
+exec: heimdallr
+dbs:
+  - path: /var/db/heimdallr.db
+    replicas:
+      - type: s3
+        bucket: broken-silence-792
+        endpoint: "fly.storage.tigris.dev"
+        path: "heimdallr.db"
+        force-path-style: true

--- a/_fly/litestream.test.yml
+++ b/_fly/litestream.test.yml
@@ -1,0 +1,9 @@
+exec: heimdallr
+dbs:
+  - path: /var/db/heimdallr-test.db
+    replicas:
+      - type: s3
+        bucket: broken-silence-792
+        endpoint: "fly.storage.tigris.dev"
+        path: "heimdallr-test.db"
+        force-path-style: true

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -4,13 +4,16 @@ primary_region = "iad"
 [build]
 dockerfile = "_fly/Dockerfile"
 
+[build.args]
+ENV = "production"
+
 [[vm]]
 size = "shared-cpu-2x"
 
 [env]
 HEIMDALLR_DEV_MODE_EANBLED = "false"
-HEIMDALLR_BOT_DB = "/litefs/heimdallr.db"
+HEIMDALLR_BOT_DB = "/var/db/heimdallr.db"
 
 [mounts]
 source = "litefs"
-destination = "/var/lib/litefs"
+destination = "/var/db"

--- a/fly.toml
+++ b/fly.toml
@@ -9,13 +9,16 @@ primary_region = 'iad'
 [build]
 dockerfile = "_fly/Dockerfile"
 
+[build.args]
+ENV = "test"
+
 [env]
 HEIMDALLR_DEV_MODE_EANBLED = "true"
-HEIMDALLR_BOT_DB = "/litefs/heimdallr-test.db"
+HEIMDALLR_BOT_DB = "/var/db/heimdallr-test.db"
 
 [[vm]]
 size = 'shared-cpu-1x'
 
 [mounts]
 source = "litefs"
-destination = "/var/lib/litefs"
+destination = "/var/db"


### PR DESCRIPTION
As fly.io is sunsetting, LiteFS Cloud, the method in which the database is backed up and replicated needs to be changed. With S3-compatible storage having been set up, this PR makes it so that the instances running on Fly.io will use Litestream instead.